### PR TITLE
git ignore custom mods/themes; fix check duplicate kill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ cache/SQL/
 cache/pheal/
 !cache/pheal/.htaccess
 cache/error.log
+cache/killadded.mk
 cache/evecentral/
 cache/img
 cache/update
@@ -38,3 +39,21 @@ cache/pheal_error.log
 # IIS7 
 web.config
 
+# Untrack custom mods
+mods/
+!mods/ajcron/
+!mods/forum_post/
+!mods/known_members/
+!mods/mail_editor/
+!mods/mail_forward/
+!mods/rss_feed/
+!mods/signature_generator/
+!mods/.htaccess
+!mods/index.php
+
+# Untrack custom themes
+themes/
+!themes/default/
+!themes/xhtml/
+!themes/generic.js
+!themes/genericfitting.css

--- a/common/includes/class.zkbfetch.php
+++ b/common/includes/class.zkbfetch.php
@@ -385,6 +385,15 @@ class ZKBFetch
     {
         $qry = DBFactory::getDBQuery();
 
+        // Check for duplicate by external ID
+        $qry->execute('SELECT kll_id FROM kb3_kills WHERE kll_external_id = '.$killData->killID);
+        if($qry->recordCount())
+        {
+            // kill is already known
+            $this->skipped[] = $killData->killID;
+            return;
+        }
+
         // Check hashes with a prepared query.
         // Make it static so we can reuse the same query for feed fetches.
         $checkHash;
@@ -448,15 +457,6 @@ class ZKBFetch
             }
             return;
         }	
-        
-        // Check for duplicate by external ID
-        $qry->execute('SELECT kll_id FROM kb3_kills WHERE kll_external_id = '.$killData->killID);
-        if($qry->recordCount())
-        {
-            // kill is already known
-            $this->skipped[] = $killData->killID;
-            return;
-        }
 
         $this->hash = $hash;
 


### PR DESCRIPTION
I run script
<code>$php cron_zkb.php</code>
and get error:
Database error: Duplicate entry '34873218' for key 'kll_external_id'
SQL: UPDATE kb3_kills JOIN kb3_mails ON kb3_mails.kll_id = kb3_kills.kll_id SET kb3_kills.kll_external_id = 34873218, kb3_mails.kll_external_id = 34873218, kll_modified_time = UTC_TIMESTAMP() WHERE kb3_kills.kll_id = 32730 AND kb3_kills.kll_external_id IS NULL
PHP Fatal error:  SQL error (Duplicate entry '34873218' for key 'kll_external_id' in /home/u5577/domains/insp.su/killboard/common/includes/class.dbnormalquery.php on line 46

This patch fix problem.
