### PR TITLE
Fix: Allow new lower alliance IDs and alliances starting with numbers

### DIFF
--- a/common/admin/option_config.php
+++ b/common/admin/option_config.php
@@ -307,9 +307,9 @@ class admin_config
 			$all_id = 0;
 		}
 
-		if ($numeric || $all_id > 0) {
+		if ($numeric && $all_id > 0) {
 			$all_id = intval($all_id);
-			if ($all_id > 100000000) { //external IDs are over 100 million
+			if ($all_id > 90000000) { //external IDs are over 90 million
 				$qry->execute("SELECT `all_name`, `all_id` FROM `kb3_alliances`"
 						." WHERE `all_external_id` = ".$all_id);
 				if (!$qry->recordCount()) {


### PR DESCRIPTION
There are alliances now with IDs lower than 100 million such as "99004222" which couldn't be added, also you couldn't add alliances with names that start with numbers as it tried to pass them as alliance IDs instead of strings.
