### PR TITLE
Pull request: Handling of dead alliances/corps Issue: #9

### DIFF
--- a/common/alliance_detail.php
+++ b/common/alliance_detail.php
@@ -256,6 +256,10 @@ class pAllianceDetail extends pageAssembly
 				$efficiency = 0;
 			}
 		}
+		else
+		{
+			Alliance::updateClosed($this->alliance->getName(),$this->alliance->getExternalID());
+		}
 		// The summary table is also used by the stats. Whichever is called
 		// first generates the table.
 		$smarty->assign('all_img', $this->alliance->getPortraitURL(128));

--- a/common/corp_detail.php
+++ b/common/corp_detail.php
@@ -202,6 +202,12 @@ class pCorpDetail extends pageAssembly
 				$this->alliance, $myAPI->getCurrentTime(),
 				$externalid = $this->corp->getExternalID());
 		}
+
+		if($myAPI->getMemberCount() == 0)
+		{
+			Corporation::updateClosed($myAPI->getCorporationName(),$this->corp->getExternalID());
+		}
+
 		$this->page->setTitle('Corporation details - '.$this->corp->getName() . " [" . $myAPI->getTicker() . "]");
 
 		$smarty->assign('portrait_url', $this->corp->getPortraitURL(128));

--- a/common/includes/class.alliance.php
+++ b/common/includes/class.alliance.php
@@ -214,6 +214,30 @@ class Alliance extends Entity
 	}
 
 	/**
+	 * Checks whether a closed alliance exists and updates the stored name if needed.
+	 *
+     * @param string $name The name of the alliance
+	 * @param int $externalid The alliance external ID
+	*/
+
+	static function updateClosed($name,$externalid = 0)
+	{
+		$qry = DBFactory::getDBQuery(true);
+
+		if(substr_count(slashfix($name),'[CLOSED]'))
+		{
+			$qry->execute("select all_name from kb3_alliances where all_name = '".slashfix($name)."' and all_external_id ='".$externalid."'");
+		}
+		else
+		{
+			$qry->execute("select all_name from kb3_alliances where all_name = '[CLOSED] ".slashfix($name)."' and all_external_id ='".$externalid."'");
+		}
+		if(!$qry->recordCount()) {
+			$qry->execute("update kb3_alliances set all_name = '[CLOSED] ".$qry->escape($name)."' where all_name = '".$qry->escape($name)."' and all_external_id ='".$externalid."'");
+		}
+	}
+
+	/**
 	 * Set the CCP external ID for this alliance.
 	 *
 	 * @param integer $externalid

--- a/common/includes/class.corporation.php
+++ b/common/includes/class.corporation.php
@@ -304,6 +304,24 @@ class Corporation extends Entity
 		}
 		return false;
 	}
+
+	/**
+	 * Checks whether a closed corporation exists and updates the stored name if needed.
+	 *
+     * @param string $name The name of the corporation
+	 * @param int $externalid The corporations external ID
+	*/
+
+	static function updateClosed($name,$externalid = 0)
+	{
+		$qry = DBFactory::getDBQuery(true);
+
+		$qry->execute("select crp_name from kb3_corps where crp_name = '[CLOSED] ".slashfix($name)."' and crp_external_id ='".$externalid."'");
+		if(!$qry->recordCount() && $externalid != 0) {
+			$qry->execute("update kb3_corps set crp_name = '[CLOSED] ".$qry->escape($name)."' where crp_name = '".$qry->escape($name)."' and crp_external_id ='".$externalid."'");
+		}
+	}
+
 	/**
 	 * Return whether this corporation was updated before the given timestamp.
 	 *


### PR DESCRIPTION
The following changes handle dead corps/alliances on our killboard which has many cases of closed alliances/corporations.

It isn't the most elegant but it works.

Please note: You need to adjust the `crp_name` and `all_name` indexes from `Unique` to `Index` in order to ensure that multiple versions of a closed alliance are tracked correctly.
