### PR TITLE
Feature: Add Redis cache system based on memcache handler + Error handler modification

### DIFF
--- a/common/admin/option_acache.php
+++ b/common/admin/option_acache.php
@@ -22,6 +22,10 @@ options::fadd('Enable SQL-Query File Cache', 'cfg_qcache', 'checkbox', '', '','S
 options::fadd('Enable SQL-Query MemCache', 'cfg_memcache', 'checkbox','','','Requires a separate memcached installation');
 options::fadd('Memcached server', 'cfg_memcache_server', 'edit:size:50');
 options::fadd('Memcached port', 'cfg_memcache_port', 'edit:size:8');
+options::fadd('Enable SQL-Query Redis', 'cfg_redis', 'checkbox','','','Requires a separate Redis installation');
+options::fadd('Redis server', 'cfg_redis_server', 'edit:size:50');
+options::fadd('Redis port', 'cfg_redis_port', 'edit:size:8');
+options::fadd('Redis database', 'cfg_redis_db', 'edit:size:8');
 options::fadd('Halt on SQLError', 'cfg_sqlhalt', 'checkbox');
 
 options::cat('Advanced', 'Cache', 'Even More Caching');
@@ -33,9 +37,14 @@ options::fadd('File Cache', 'none', 'custom', array('admin_acache', 'optionClear
 options::fadd('Kill Summary Cache', 'none', 'custom', array('admin_acache', 'optionClearSum'), array('admin_acache', 'clearSumCache'));
 
 global $mc;
+global $redis;
 if(defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true && !is_null($mc) && method_exists('Memcache', 'flush'))
 {
     options::fadd('MemCache', 'none', 'custom', array('admin_acache', 'optionFlushMemcached'), array('admin_acache', 'flushMemcached'));
+}
+if(defined('DB_USE_REDIS') && DB_USE_REDIS == true && !is_null($redis) && method_exists('Redis', 'flushDb'))
+{
+    options::fadd('Redis', 'none', 'custom', array('admin_acache', 'optionFlushRedis'), array('admin_acache', 'flushRedis'));
 }
 
 class admin_acache
@@ -71,9 +80,13 @@ class admin_acache
 	{
 		return '<input type="checkbox" name="option_clear_sum" />Clear cache ?';
 	}
-        function optionFlushMemcached()
+    function optionFlushMemcached()
 	{
 		return '<input type="checkbox" name="option_flush_memcached" />Flush MemCache ?';
+	}
+	function optionFlushRedis()
+	{
+		return '<input type="checkbox" name="option_flush_redis" />Flush Redis ?';
 	}
 	function clearCaches()
 	{
@@ -102,7 +115,8 @@ class admin_acache
 			$_POST['option_clear_sum'] == 'off';
         }
 	}
-        function flushMemcached()
+    
+	function flushMemcached()
 	{
             global $mc;
             // Check for memcached
@@ -111,5 +125,16 @@ class admin_acache
                 $mc->flush();
             }
             $_POST['option_flush_memcached'] = 'off';
+	}
+	
+	function flushRedis()
+	{
+            global $redis;
+            // Check for Redis
+            if(defined('DB_USE_REDIS') && DB_USE_REDIS == true && !is_null($redis) && method_exists('Redis', 'flushDb'))
+            {
+                $redis->flushDb('cfg_redis_db');
+            }
+            $_POST['option_flush_redis'] = 'off';
 	}
 }

--- a/common/includes/class.cache.php
+++ b/common/includes/class.cache.php
@@ -24,7 +24,7 @@ class cache
 	/**
 	 * Check the server load using /proc/loadavg.
 	 *
-	 * Changes reinforced statust depending on load where supported.
+	 * Changes reinforced status depending on load where supported.
 	 *
 	 * @return bool true if the server is reinforced, false if not or not
 	 * supported
@@ -106,6 +106,8 @@ class cache
 		$cachefile = cache::genCacheName();
 		if (defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true) {
 			$cachehandler = new CacheHandlerHashedMem();
+		}  elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
+			$cachehandler = new CacheHandlerHashedRedis();
 		} else {
 			$cachehandler = new CacheHandlerHashed();
 		}
@@ -194,6 +196,8 @@ class cache
 
 			if (DB_USE_MEMCACHE) {
 				$cachehandler = new CacheHandlerHashedMem();
+			} elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
+				$cachehandler = new CacheHandlerHashedRedis();
 			} else {
 				$cachehandler = new CacheHandlerHashed();
 			}
@@ -248,6 +252,8 @@ class cache
 
 		if (DB_USE_MEMCACHE) {
 			$cachehandler = new CacheHandlerHashedMem();
+		} elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
+			$cachehandler = new CacheHandlerHashedRedis();
 		} else {
 			$cachehandler = new CacheHandlerHashed();
 		}

--- a/common/includes/class.cache.php
+++ b/common/includes/class.cache.php
@@ -194,7 +194,7 @@ class cache
 					&& !ini_get('zlib.output_compression');
 			$cachefile = cache::genCacheName();
 
-			if (DB_USE_MEMCACHE) {
+			if (defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true) {
 				$cachehandler = new CacheHandlerHashedMem();
 			} elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
 				$cachehandler = new CacheHandlerHashedRedis();
@@ -250,9 +250,9 @@ class cache
 	{
 		$cachefile = cache::genCacheName();
 
-		if (DB_USE_MEMCACHE) {
+		if (defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true) {
 			$cachehandler = new CacheHandlerHashedMem();
-		} elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
+		}  elseif (defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
 			$cachehandler = new CacheHandlerHashedRedis();
 		} else {
 			$cachehandler = new CacheHandlerHashed();

--- a/common/includes/class.cacheable.php
+++ b/common/includes/class.cacheable.php
@@ -138,13 +138,15 @@ abstract class Cacheable {
 	/**
 	 * Initialise the cachehandler.
 	 *
-	 * Sets a new cachehandler, choosing between memcache or filecache
+	 * Sets a new cachehandler, choosing between memcache, redis or filecache
 	 * depending on killboard settings.
 	 */
 	private static function init()
 	{
 		if(defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true) {
 			self::$cachehandler = new CacheHandlerHashedMem();
+		} elseif(defined('DB_USE_REDIS') && DB_USE_REDIS == true) {
+			self::$cachehandler = new CacheHandlerHashedRedis();
 		} else {
 			self::$cachehandler = new CacheHandlerHashed();
 		}

--- a/common/includes/class.cachehandlerhashedredis.php
+++ b/common/includes/class.cachehandlerhashedredis.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * $Date$
+ * $Revision$
+ * $HeadURL$
+ * @package EDK
+ */
+
+
+/**
+ * Hashed object caching class backed by redis
+ * Extends the cache handler to handle any type of object. Instead of
+ * using the given filename a key is used to create a hashed name.
+ * @package EDK
+ */
+class CacheHandlerHashedRedis extends CacheHandlerHashed
+{
+	private static $maxage = 43200;
+	
+	/**
+	 * Add a file to the cache.
+	 *
+	 * @param string $key The key for the required object.
+	 * @param mixed$object The object to store.
+	 * @param string $location Fetch from a particular location if needed. (identical to $key.$location)
+	 *
+	 * @return boolean true if successful, false if an error occurred.
+	 */
+	public static function put($key, $data, $location = '', $age = null)
+	{
+		global $redis;
+
+		$data = serialize($data);
+		if(is_null($age)) $age = self::$maxage;
+		if($age && $age > 5) $age = $age * (105 - rand(0, 10))/100;
+		$hash = self::hash($key.$location);
+		$result = $redis->set($hash, $data, $age);
+		if(!$result) $result = $redis->set($hash, $data, $age);
+		//
+		// record age separately
+		$hash .= "age";
+		$result = $redis->set($hash, time(), $age);
+		if(!$result) $result = $redis->set($hash, time(), $age);
+
+		return $result;
+	}
+	/**
+	 * Get a file from the cache
+	 *
+	 * @param string $key The key for the required object.
+	 * @param string $location Fetch from a particular location if needed.
+	 *
+	 * @return mixed A copy of the stored object.
+	 */
+	public static function get($key, $location = '')
+	{
+		global $redis;
+
+		$hash = self::hash($key.$location);
+		return unserialize($redis->get($hash));
+	}
+	/**
+	 * Return true if the file is in the cache.
+	 *
+	 * @param string $key The key for the required object.
+	 * @param string $location Fetch from a particular location if needed.
+	 *
+	 * @return boolean true if the stored object exists, false otherwise.
+	 */
+	public static function exists($key, $location = '')
+	{
+		global $redis;
+
+		$hash = self::hash($key,$location);
+		return $redis->get($hash) !== false;
+	}
+	/**
+	 * Get the externally accessible address of the cached file.
+	 *
+	 * @return boolean false. There is no valid path to a redis object.
+	 */
+	public static function getExternal()
+	{
+		return false;
+	}
+	/**
+	 * Get the internally accessible address of the cached file.
+	 *
+	 * @return boolean false. There is no valid path to a redis object.
+	 */
+	public static function getInternal()
+	{
+		return false;
+	}
+	/**
+	 * Get the hash of the given $key.$location.
+	 *
+	 * @param string $key
+	 * @param string $location
+	 * @return string
+	 */
+	private static function hash($key, $location = '')
+	{
+		return md5($key.$location);
+	}
+	/**
+	 * Remove a cached object
+	 *
+	 * @param string $key The key for the required object.
+	 * @param string $location Fetch from a particular location if needed.
+	 *
+	 * @return boolean true if removed or not in the cache, false on failure.
+	 */
+	public static function remove($key, $location = '')
+	{
+		global $redis;
+
+		$hash = self::hash($key.$location);
+		return $redis->delete($hash);
+	}
+	/**
+	 * Return the age of the given cache file.
+	 *
+	 * @param string $key The key for the required object.
+	 * @param string $location Fetch from a particular location if needed.
+	 *
+	 * @return integerThe age in seconds of the stored object.
+	 */
+	public static function age($key, $location = '')
+	{
+		global $redis;
+
+		$hash = self::hash($key.$location)."age";
+		$age = $redis->get($hash);
+		if($age === false) return false;
+		return time() - (int)$age;
+	}
+	/**
+	 * Set the default maximum age.
+	 *
+	 * @param integer $age The new default maximum age
+	 */
+	public static function setMaxAge($age = 0)
+	{
+		self::$maxage = $age;
+	}
+}

--- a/common/includes/class.dbfactory.php
+++ b/common/includes/class.dbfactory.php
@@ -26,6 +26,10 @@ class DBFactory
 		{
 			return new DBMemCachedQuery($forceNormal);
 		}
+		else if (defined('DB_USE_REDIS') && DB_USE_REDIS == true)
+		{
+			return new DBRedisQuery($forceNormal);
+		}
 		else if (defined('DB_USE_QCACHE') && DB_USE_QCACHE == true)
 		{
 			return new DBCachedQuery($forceNormal);

--- a/common/includes/class.dbpreparedquery.php
+++ b/common/includes/class.dbpreparedquery.php
@@ -74,7 +74,7 @@ class DBPreparedQuery
 		$t1 = microtime(true);
 
 		//TODO redo this with hooks that cached classes can use.
-		if ( (DB_USE_MEMCACHE || DB_USE_QCACHE )
+		if ( (DB_USE_MEMCACHE || DB_USE_REDIS || DB_USE_QCACHE )
 			&& strtolower(substr($this->sql, 0, 6)) != 'select'
 			&& strtolower(substr($this->sql, 0, 4)) != 'show')
 		{

--- a/common/includes/class.dbredisquery.php
+++ b/common/includes/class.dbredisquery.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * $Date$
+ * $Revision$
+ * $HeadURL$
+ * @package EDK
+ */
+
+/**
+ * mysqli Redis query class. Manages SQL queries to a MySQL DB using mysqli.
+ * @package EDK
+ */
+class DBRedisQuery extends DBCachedQuery
+{
+	/**
+	 * Set up a mysqli cached query object with default values.
+	 *
+	 * @param boolean $nocache true to retrieve results directly from the db.
+	 */
+	function DBRedisQuery($nocache = false)
+	{
+		$this->nocache = $nocache;
+
+		self::$cachehandler = new CacheHandlerHashedRedis();
+
+		if(is_null(self::$maxmem))
+		{
+			$tmp = @ini_get('memory_limit');
+			$tmp = @str_replace('M', '000000', $tmp) * 0.8;
+			self::$maxmem = @intval(str_replace('G', '000000000', $tmp) * 0.8);
+			if(!self::$maxmem) {
+				self::$maxmem = 128000000;
+			}
+		}
+	}
+}

--- a/common/includes/class.edkerror.php
+++ b/common/includes/class.edkerror.php
@@ -67,8 +67,11 @@ class EDKError
 				rename($logfile, $logfile.".old");
 			}
 		}
-		echo $output;
-		self::$errors[] = $output;
+		if (ini_get('display_errors'))
+		{
+			echo $output;
+			self::$errors[] = $output;
+		}
 		return true;
 	}
 }

--- a/common/includes/db.php
+++ b/common/includes/db.php
@@ -94,8 +94,11 @@ else
 					$boardMessage = "ERROR: Unable to connect to Redis server, disabling Redis. Please check your settings (server, port, database) and make sure the Redis server is running";
 					define("DB_USE_REDIS", false);
 				}
-				else define("DB_USE_REDIS", true);
-				if(method_exists('Redis', 'select')) $redis->select(config::get('cfg_redis_db'));
+				else
+				{
+					if(method_exists('Redis', 'select')) $redis->select(config::get('cfg_redis_db'));
+					define("DB_USE_REDIS", true);
+				}
 			}
 		} else {
 			define("DB_USE_MEMCACHE", false);

--- a/common/includes/db.php
+++ b/common/includes/db.php
@@ -34,10 +34,23 @@ if(defined('DB_USE_MEMCACHE') && DB_USE_MEMCACHE == true)
 			sure the memcached server is running");
 	else if(method_exists(Memcache, 'setCompressThreshold')) $mc->setCompressThreshold(10000, 0.2);
 }
+else if(defined('DB_USE_REDIS') && DB_USE_REDIS == true)
+{
+	if(!defined('DB_REDIS_SERVER') || !defined('DB_REDIS_PORT'))
+		die("DB_REDIS_SERVER and DB_REDIS_PORT not defined. Redis not started.");
+
+	$redis = new Redis();
+	if(!@$redis->pconnect(DB_REDIS_SERVER, DB_REDIS_PORT))
+		die("ERROR: Unable to connect to Redis server, disabling
+			Redis. Please check your settings (server, port) and make
+			sure the Redis server is running");
+	else if(method_exists('Redis', 'select')) $redis->select(DB_REDIS_DB);
+}
 // If DB_USE_QCACHE is defined then it needs no further setup.
 else if(defined('DB_USE_QCACHE'))
 { 
 	if(!defined('DB_USE_MEMCACHE')) define('DB_USE_MEMCACHE', false);
+	if(!defined('DB_USE_REDIS')) define('DB_USE_REDIS', false);
 }
 else
 {
@@ -45,27 +58,49 @@ else
 
 	define('DB_USE_QCACHE', (bool)config::get('cfg_qcache'));
 
-	if (!DB_USE_QCACHE && (bool)config::get('cfg_memcache'))
+	if (!DB_USE_QCACHE)
 	{
-		if(!method_exists('Memcache', 'pconnect'))
+		if ((bool)config::get('cfg_memcache'))
 		{
-			$boardMessage = "ERROR: Memcache extension not installed. memcaching disabled.";
-			define("DB_USE_MEMCACHE", false);
-		}
-		else
-		{
-			$mc = new Memcache();
-			if(!@$mc->pconnect(config::get('cfg_memcache_server'), config::get('cfg_memcache_port')))
+			if(!method_exists('Memcache', 'pconnect'))
 			{
-				$boardMessage = "ERROR: Unable to connect to memcached server, disabling memcached. Please check your settings (server, port) and make sure the memcached server is running";
+				$boardMessage = "ERROR: Memcache extension not installed. memcaching disabled.";
 				define("DB_USE_MEMCACHE", false);
 			}
-			else define("DB_USE_MEMCACHE", true);
-			if(method_exists('Memcache', 'setCompressThreshold')) $mc->setCompressThreshold(20000, 0.2);
+			else
+			{
+				$mc = new Memcache();
+				if(!@$mc->pconnect(config::get('cfg_memcache_server'), config::get('cfg_memcache_port')))
+				{
+					$boardMessage = "ERROR: Unable to connect to memcached server, disabling memcached. Please check your settings (server, port) and make sure the memcached server is running";
+					define("DB_USE_MEMCACHE", false);
+				}
+				else define("DB_USE_MEMCACHE", true);
+				if(method_exists('Memcache', 'setCompressThreshold')) $mc->setCompressThreshold(20000, 0.2);
+			}
 		}
-	} else
-	{
-		define("DB_USE_MEMCACHE", false);
+		elseif ((bool)config::get('cfg_redis'))
+		{
+			if(!method_exists('Redis', 'pconnect'))
+			{
+				$boardMessage = "ERROR: Redis extension not installed. Redis disabled.";
+				define("DB_USE_REDIS", false);
+			}
+			else
+			{
+				$redis = new Redis();
+				if(!@$redis->pconnect(config::get('cfg_redis_server'), config::get('cfg_redis_port')))
+				{
+					$boardMessage = "ERROR: Unable to connect to Redis server, disabling Redis. Please check your settings (server, port, database) and make sure the Redis server is running";
+					define("DB_USE_REDIS", false);
+				}
+				else define("DB_USE_REDIS", true);
+				if(method_exists('Redis', 'select')) $redis->select(config::get('cfg_redis_db'));
+			}
+		} else {
+			define("DB_USE_MEMCACHE", false);
+			define("DB_USE_REDIS", false);
+		}
 	}
 }
 

--- a/install/config.data
+++ b/install/config.data
@@ -61,4 +61,7 @@ cfg_log	1
 cfg_sqlhalt	1
 cfg_objcache	1
 cfg_ccpimages	1
-
+cfg_redis	0
+cfg_redis_server	0.0.0.0
+cfg_redis_port	0
+cfg_redis_db	0

--- a/thumb.php
+++ b/thumb.php
@@ -119,7 +119,7 @@ function goPCA($type, $id, $size = 64, $imghost = "")
 	header("Expires: ".gmdate("D, d M Y H:i:s", time() + $year)." GMT");
 
 	header('Last-Modified: '.gmdate("D, d M Y H:i:s")." GMT");
-	global $mc, $config;
+	global $mc, $redis, $config;
 	include_once('kbconfig.php');
 	require_once('common/includes/globals.php');
 	$config = new Config();
@@ -135,7 +135,7 @@ function goPCA($type, $id, $size = 64, $imghost = "")
 
 function goMap($type, $id, $size=200)
 {
-	global $mc, $config;
+	global $mc, $redis, $config;
 	//TODO integrate the existing common/includes/class.mapview.php
 	include_once('kbconfig.php');
 	require_once('common/includes/globals.php');

--- a/update/index.php
+++ b/update/index.php
@@ -16,6 +16,7 @@ ini_set('display_errors', 1);
 define('DB_HALTONERROR', true);
 define('DB_USE_QCACHE', false);
 define('DB_USE_MEMCACHE',false);
+define('DB_USE_REDIS',false);
 define('KB_CACHEDIR', "cache");
 
 chdir("..");


### PR DESCRIPTION
This is a very simple Redis cache handler based on the memcache handler as an alternative to the memcached caching.

Also PHP errors should only be displayed on the frontend if the user has `display_errors` on, this adds a conditional to check.
