### PR TITLE
added keepstar to valuefetcher and removed evecentral sync

### DIFF
--- a/common/includes/class.valuefetcheresi.php
+++ b/common/includes/class.valuefetcheresi.php
@@ -97,7 +97,7 @@ class ValueFetcherEsi
     /**
      *  handle item values not correctly represented by market/adjustedPrice, e.g. super capitals
      * @param int $typeId the typeID for the item
-     * @param double $itemPrice the item price returned by CREST
+     * @param double $itemPrice the item price returned by ESI
      */
     public static function handleSpecialItemValues($typeId, $itemPrice)
     {
@@ -223,6 +223,12 @@ class ValueFetcherEsi
         else if(in_array($typeId, array(13202, 26840, 11936, 11938, 26842)))
         {
             return "750000000000";
+        }
+
+        // Keepstar => 300b
+        else if($typeId == 35834)
+        {
+            return "300000000000";
         }
         
         

--- a/themes/default/templates/value_editor.tpl
+++ b/themes/default/templates/value_editor.tpl
@@ -24,7 +24,6 @@
 		&nbsp;&nbsp;<input type='submit' value='Save'>
 		</form>
 	</td>
-	{if $eve_central_exists eq "1"}<td><a href='{$kb_host}/?a=admin_value_editor&amp;itm_id={$results[opt].id}&amp;d=eve_central&amp;item_type={$type}'>Sync to EVE Central</a></td>{/if}
 	</td>
 </tr>
 {sectionelse}

--- a/themes/xhtml/templates/value_editor.tpl
+++ b/themes/xhtml/templates/value_editor.tpl
@@ -24,7 +24,6 @@
 		&nbsp;&nbsp;<input type='submit' value='Save'>
 		</form>
 	</td>
-	{if $eve_central_exists eq "1"}<td><a href='{$kb_host}/?a=admin_value_editor&amp;itm_id={$results[opt].id}&amp;d=eve_central&amp;item_type={$type}'>Sync to EVE Central</a></td>{/if}
 	</td>
 </tr>
 {sectionelse}


### PR DESCRIPTION
I noticed how keepstar don't have a value on kills due to no price being returned from `GET /market/prices`.
also removed the old "sync to eve central" link in the manual values edit view.

I haven't gone over the other 0-returned priced from the endpoint, might be worth checking if the special cases list is complete.
I wrote a small script that pulls the current 0-returned prices and puts them in json with some other info (https://dev.eve-stuff.com/prices.php). Just takes a minute or so to generate.