### PR TITLE
Fixed missing use in pilot_detail page.

### DIFF
--- a/common/pilot_detail.php
+++ b/common/pilot_detail.php
@@ -6,6 +6,7 @@
  * @package EDK
  */
 use Swagger\Client\ApiException;
+use EDK\ESI\ESI;
 
 /*
  * @package EDK


### PR DESCRIPTION
This commit fixes blank page for pilot_detail due to an error stating ESI is missing.

As requested in #96.