### PR TITLE
Remove usage of deprecated Redis "delete" function and change to "del"

### DIFF
--- a/common/includes/class.cachehandlerhashedredis.php
+++ b/common/includes/class.cachehandlerhashedredis.php
@@ -117,7 +117,7 @@ class CacheHandlerHashedRedis extends CacheHandlerHashed
         global $redis;
 
         $hash = self::hash($key.$location);
-        return $redis->delete($hash);
+        return $redis->del($hash);
     }
     /**
      * Return the age of the given cache file.


### PR DESCRIPTION
The Redis `delete` function is an alias to `del` and is deprecated, this replaces the usage of the function to `del`