### PR TITLE
Updated image urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ cache/killadded.mk
 .cache
 .project
 .settings
+.idea
 
 # IIS7 
 web.config

--- a/common/includes/class.imageurl.php
+++ b/common/includes/class.imageurl.php
@@ -66,7 +66,7 @@ class imageURL
             switch ($type) {
                 case 'Character':
                 case 'Pilot':
-                    $url .= "/Character/{$id}_{$size}.jpg";
+                    $url .= "/characters/{$id}/portrait?size={$size}";
                     break;
                 case 'Corporation':
                 case 'Alliance':

--- a/common/includes/class.imageurl.php
+++ b/common/includes/class.imageurl.php
@@ -72,9 +72,9 @@ class imageURL
                 case 'Alliance':
                     // Check for NPC alliances recorded as corps.
                     if ($id > 500000 && $id < 500021) {
-                        $url .= "/Alliance/{$id}_{$size}.png";
+                        $url .= "/alliances/{$id}/logo?size={$size}";
                     } else {
-                        $url .= "/$type/{$id}_{$size}.png";
+                        $url .= '/' . strtolower($type) . "s/{$id}/logo?size={$size}";
                     }
                     break;
                 case 'Type':

--- a/common/includes/class.imageurl.php
+++ b/common/includes/class.imageurl.php
@@ -81,12 +81,12 @@ class imageURL
                 case 'InventoryType':
                 case 'Ship':
                     if ($size > 64 && $type == 'Ship')
-                        $url .= "/Render/{$id}_{$size}.png";
+                        $url .= "/types/{$id}/render?size={$size}";
                     else
-                        $url .= "/InventoryType/{$id}_{$size}.png";
+                        $url .= "/types/{$id}/icon?size={$size}";
                     break;
                 case 'Render':
-                    $url .= "/Render/{$id}_{$size}.png";
+                    $url .= "/types/{$id}/render?size={$size}";
                     break;
                 default:
                     $url .= "/{$type}/{$id}_{$size}.png";

--- a/common/includes/constants.php
+++ b/common/includes/constants.php
@@ -21,7 +21,7 @@ define('KB_QUERYCACHEDIR', KB_CACHEDIR . '/SQL');
 /** URL where to find EDK update information */
 define('KB_UPDATE_URL', 'http://evekb.org/downloads');
 /** base URL for the image server */
-define('IMG_SERVER', "https://imageserver.eveonline.com");
+define('IMG_SERVER', "https://images.evetech.net");
 /** data source for ESI calls */
 define('ESI_DATA_SOURCE', 'tranquility');
 /** SOO OAuth base URL */
@@ -31,7 +31,7 @@ define('OAUTH_BASE_URL', 'https://login.eveonline.com/oauth');
  * current version: major.minor.sub.ccpDBupdateNo
  * even numbers for minor = development version
  */
-define('KB_VERSION', '4.4.3.0');
+define('KB_VERSION', '4.4.4.0');
 /** release name */
 define('KB_RELEASE', '(July 2019 1.0)');
 /** version of the SDE used to produce the current static database */


### PR DESCRIPTION
This updates the urls used for the different types according to [CCP Image server](https://imageserver.eveonline.com/). It fixes the errors reported in #114 

I have tested this on my own killboard, and it fixed the errors I was seeing. Hopefully this will be included in an update.