### PR TITLE
Fixes for php 7.4, MySQL 8, and image servers

### DIFF
--- a/common/alliance_detail.php
+++ b/common/alliance_detail.php
@@ -68,7 +68,7 @@ class pAllianceDetail extends pageAssembly
         $this->queue("stats");
         $this->queue("summaryTable");
         $this->queue("killList");
-                $this->queue("metaTags");
+        $this->queue("metaTags");
     }
 
     /**
@@ -114,6 +114,7 @@ class pAllianceDetail extends pageAssembly
                 exit;
             }
         } else {
+		# at this point you can call $this->alliance->getName()
             $this->alliance = Cacheable::factory('Alliance', $this->all_id);
             $this->all_external_id = $this->alliance->getExternalID();
         }
@@ -199,8 +200,10 @@ class pAllianceDetail extends pageAssembly
 
         // Use alliance ID if we have it
         if (!$this->alliance->getExternalID()) 
-        {
-            $allianceID = ESI_Helpers::getExternalIdForEntity($this->alliance->getName(), 'alliance');
+	{
+            // The search API no longer works. 
+            // This would now have to query /universe/ids/<name> for the alliance
+            // $allianceID = ESI_Helpers::getExternalIdForEntity($this->alliance->getName(), 'alliance');
             if(isset($allianceID))
             {
                 $this->alliance->setExternalID($allianceID);
@@ -229,7 +232,6 @@ class pAllianceDetail extends pageAssembly
 
             else 
             {
-                
                 $EdkEsi = new ESI();
                 $AllianceApi = new AllianceApi($EdkEsi);
                 $AllianceDetails = $AllianceApi->getAlliancesAllianceId($this->alliance->getExternalID(), $EdkEsi->getDataSource());
@@ -901,7 +903,8 @@ class pAllianceDetail extends pageAssembly
         $metaTagDescription = $this->alliance->getName();
         if($this->allianceDetails)
         {
-            $metaTagDescription .= " [" . $this->allianceDetails['shortName'] . "] (" . $this->allianceDetails['memberCount'] . " Members in " . count($this->allianceDetails['memberCorps']) . " Corps)";
+            $memberCount = $this->allianceDetails['memberCorps'] == null ? 0 : count($this->allianceDetails['memberCorps']);
+            $metaTagDescription .= " [" . $this->allianceDetails['shortName'] . "] (" . $this->allianceDetails['memberCount'] . " Members in " . $memberCount . " Corps)";
         }
         $metaTagDescription .= " has " . $this->kill_summary->getTotalKills() . " kills and " . $this->kill_summary->getTotalLosses() . " losses (Efficiency: ".$this->efficiency."%) at " . config::get('cfg_kbtitle');
 

--- a/common/esi/lib/EsiClient/CorporationApi.php
+++ b/common/esi/lib/EsiClient/CorporationApi.php
@@ -141,7 +141,7 @@ class CorporationApi
         }
 
         // parse inputs
-        $resourcePath = "/v4/corporations/{corporation_id}/";
+        $resourcePath = "/v5/corporations/{corporation_id}/";
         $httpBody = '';
         $queryParams = array();
         $headerParams = array();

--- a/common/includes/class.imageurl.php
+++ b/common/includes/class.imageurl.php
@@ -83,7 +83,7 @@ class imageURL
                     if ($size > 64 && $type == 'Ship')
                         $url .= "/Render/{$id}_{$size}.png";
                     else
-                        $url .= "/InventoryType/{$id}_{$size}.png";
+                        $url .= "/types/{$id}/icon";
                     break;
                 case 'Render':
                     $url .= "/Render/{$id}_{$size}.png";

--- a/common/includes/class.item.php
+++ b/common/includes/class.item.php
@@ -420,7 +420,7 @@ class Item extends Cacheable
             $typeName = "Unknown Type ".$typeId;
 
             $query = new DBPreparedQuery();
-            $query->prepare('INSERT INTO kb3_invtypes (`typeID`, `typeName`) VALUES (?, ?)');
+            $query->prepare("INSERT INTO kb3_invtypes (`typeID`, `typeName`, `description`) VALUES (?, ?, '')");
             $types = 'is';
             $arr2 = array(&$types, &$typeId, &$typeName);
             $query->bind_params($arr2);

--- a/common/includes/class.itemlist.php
+++ b/common/includes/class.itemlist.php
@@ -126,7 +126,7 @@ class ItemList
         }
 
         if (count($this->destroyedIDarray) || count($this->droppedIDarray)) {
-            $sql .= "group by itd.itd_itm_id, itd.itd_itl_id, itd.itd_singleton "
+            $sql .= "GROUP BY itd.itd_itm_id, itd.itd_itl_id, itd.itd_singleton, dl.value, te.effectID, dl.attributeID "
                     ."order by itd.itd_itl_id ";
         }
 

--- a/common/includes/class.killlist.php
+++ b/common/includes/class.killlist.php
@@ -16,10 +16,10 @@ class KillList
     private $killisk_ = 0;
     private $exclude_scl_ = array();
     private $vic_scl_id_ = array();
-        private $vic_sc_id_ = array();
+    private $vic_sc_id_ = array();
     private $regions_ = array();
     private $systems_ = array();
-        private $locations_ = array();
+    private $locations_ = array();
     private $groupby_ = array();
     private $offset_ = 0;
     private $killcounter_ = 0;
@@ -47,7 +47,7 @@ class KillList
     private $inv_plt_ = array();
     private $inv_crp_ = array();
     private $inv_all_ = array();
-        private $inv_shp_ = array();
+    private $inv_shp_ = array();
     private $vic_plt_ = array();
     private $vic_crp_ = array();
     private $vic_all_ = array();
@@ -64,11 +64,12 @@ class KillList
     function __construct()
     {
         $this->qry_ = DBFactory::getDBQuery();
-        $this->expr = array("kll.kll_id",
+        $this->expr = [
+            "kll.kll_id",
             "kll.kll_timestamp",
             "kll.kll_external_id",
-                        "mdn.itemID",
-                        "mdn.itemName",
+            "mdn.itemID",
+            "mdn.itemName",
             "plt.plt_name",
             "crp.crp_name",
             "crp.crp_id",
@@ -96,7 +97,8 @@ class KillList
             "fbcrp.crp_name as fbcrp_name",
             "fbali.all_name as fball_name",
             "fbcrp.crp_id as fbcrp_id",
-            "fbali.all_id as fball_id");
+            "fbali.all_id as fball_id",
+        ];
     }
 
     private function makeKllQuery($startdate, $enddate)
@@ -183,7 +185,10 @@ class KillList
             {
                 if (!$this->orderby_)
                 {
-                    if($this->comb_plt_ || ($this->comb_crp_ && $this->comb_all_)) $sql .= " order by ind.ind_timestamp desc";
+                    // make sure ind.ind_timestamp is in select list 
+                    if($this->comb_plt_ || ($this->comb_crp_ && $this->comb_all_)) {
+                        $sql .= " order by ind.ind_timestamp desc";
+                    }
                     else if($this->comb_crp_ ) $sql .= " order by inc.inc_timestamp desc";
                     else $sql .= " order by ina.ina_timestamp desc";
                 }
@@ -300,6 +305,11 @@ class KillList
 
             $this->sqlinner_ = $this->makeKllQuery($startdate, $enddate);
 
+	    // Patching group by clause on newer mysql versions
+	    if ($this->ordered_ && !$this->orderby_ && (($this->inv_plt_ || ($this->inv_crp_ && $this->inv_all_)))) {
+                $this->addExpression("ind.ind_timestamp");
+            }
+
             if (!count($this->groupby_) && ($this->comments_ || $this->involved_))
             {
                 $this->sqloutertop_ = 'SELECT list.* ';
@@ -310,8 +320,9 @@ class KillList
             if (!count($this->groupby_))
             {
                 $this->sqltop_ = 'SELECT ';
-                if(count($this->inv_all_) + count($this->inv_crp_) + count($this->inv_plt_) > 1 || count($this->inv_shp_) > 0)
+                if(count($this->inv_all_) + count($this->inv_crp_) + count($this->inv_plt_) > 1 || count($this->inv_shp_) > 0) {
                     $this->sqltop_ .= ' DISTINCT ';
+                }
                 $this->sqltop_ .= implode(', ', $this->expr);
                 event::call('killlist_select_expr', $this->sqltop_);
             }
@@ -408,14 +419,13 @@ class KillList
                         WHERE inc.inc_crp_id in (".implode(',', $this->inv_crp_)." ) ";
                     if($startdate) $this->sql_ .=" AND inc.inc_timestamp >= '".gmdate('Y-m-d H:i:s',$startdate)."' ";
                     if($enddate) $this->sql_ .=" AND inc.inc_timestamp <= '".gmdate('Y-m-d H:i:s',$enddate)."' ";
-                }
-                                
-                                else if($this->inv_shp_)
+                }                
+                else if($this->inv_shp_)
                                 {
-                                        $this->sql_ .= " WHERE ind.ind_shp_id in (".implode(',', $this->inv_shp_)." ) ";
+                    $this->sql_ .= " WHERE ind.ind_shp_id in (".implode(',', $this->inv_shp_)." ) ";
                     if($startdate) $this->sql_ .=" AND ind.ind_timestamp >= '".gmdate('Y-m-d H:i:s',$startdate)."' ";
                     if($enddate) $this->sql_ .=" AND ind.ind_timestamp <= '".gmdate('Y-m-d H:i:s',$enddate)."' ";
-                                }
+                }
 
                 // victim filter
                 if($this->vic_plt_ || $this->vic_crp_ || $this->vic_all_)
@@ -436,7 +446,7 @@ class KillList
 
                 // System filter
                 if (count($this->systems_))
-                    $this->sql_ .= " AND kll.kll_system_id in ( ".implode($this->systems_, ",").")";
+                    $this->sql_ .= " AND kll.kll_system_id in ( ".implode(",", $this->systems_).")";
                                 // Location filter
                                 if (count($this->locations_))
                                         $this->sql_ .= " AND kll.kll_location in ( ".implode($this->locations_, ",").")";
@@ -472,7 +482,9 @@ class KillList
                 {
                     if (!$this->orderby_)
                     {
-                        if($this->inv_plt_ || ($this->inv_crp_ && $this->inv_all_)) $this->sql_ .= " order by ind.ind";
+                        if($this->inv_plt_ || ($this->inv_crp_ && $this->inv_all_)) {
+                            $this->sql_ .= " order by ind.ind";
+                        }
                         elseif($this->inv_all_ ) $this->sql_ .= " order by ina.ina";
                         elseif($this->inv_crp_ ) $this->sql_ .=" order by inc.inc";
                         else $this->sql_ .= " order by ind.ind";
@@ -480,6 +492,7 @@ class KillList
                     }
                     else $this->sql_ .= " order by ".$this->orderby_;
                 }
+
             }
             else
             {
@@ -584,8 +597,16 @@ class KillList
             {
                 $this->sqlouterbottom_ .= ") list";
                 if($this->involved_) $this->sqlouterbottom_ .= ' join kb3_inv_detail ind ON (ind.ind_kll_id = list.kll_id)';
-                if($this->comments_) $this->sqlouterbottom_ .= ' left join kb3_comments com ON (list.kll_id = com.kll_id AND (com.site = "'.KB_SITE.'" OR com.site IS NULL))';
-                $this->sqlouterbottom_ .= " group by list.kll_id";
+                if($this->comments_) { 
+                    $this->sqlouterbottom_ .= ' LEFT JOIN kb3_comments com ON (list.kll_id = com.kll_id AND (com.site = "'.KB_SITE.'" OR com.site IS NULL))';
+                }
+                $this->sqlouterbottom_ .= " GROUP BY list.kll_id, list.fbcrp_name, fball_name";
+
+                // fix group by in newer mysql versions
+                if ($this->ordered_ && !$this->orderby_ && (($this->inv_plt_ || ($this->inv_crp_ && $this->inv_all_)))) {
+                    $this->sqlouterbottom_ .= ", list.ind_timestamp";
+                }
+
                 // Outer query also needs to be ordered, if there's an order
                 if ($this->ordered_)
                 {
@@ -598,15 +619,13 @@ class KillList
             elseif ($this->plimit_)
             {
                 $splitq = DBFactory::getDBQuery();
-                $ssql = 'SELECT DISTINCT kll_id FROM '.$this->sqlinner_.$this->sql_;
+                $ssql = 'SELECT DISTINCT kll_id, ind.ind_timestamp FROM '.$this->sqlinner_.$this->sql_;
                 $splitq->execute($ssql);
 
                 $this->count_ = $splitq->recordCount();
                 $this->sql_ .= " limit ".$this->plimit_." OFFSET ".$this->poffset_;
             }
             $this->sql_ = $this->sqloutertop_.$this->sqltop_.$this->sqllong_.$this->sql_.$this->sqlouterbottom_;
-            $this->sql_ .= " /* kill list */";
-            //            die($this->sql_);
             $this->qry_->execute($this->sql_);
             if(!$this->plimit_ || $this->limit_) $this->count_ = $this->qry_->recordcount();
             $this->executed = true;

--- a/common/includes/constants.php
+++ b/common/includes/constants.php
@@ -21,7 +21,7 @@ define('KB_QUERYCACHEDIR', KB_CACHEDIR . '/SQL');
 /** URL where to find EDK update information */
 define('KB_UPDATE_URL', 'http://evekb.org/downloads');
 /** base URL for the image server */
-define('IMG_SERVER', "https://imageserver.eveonline.com");
+define('IMG_SERVER', "https://images.evetech.net");
 /** data source for ESI calls */
 define('ESI_DATA_SOURCE', 'tranquility');
 /** SOO OAuth base URL */

--- a/common/includes/toplist/class.base.php
+++ b/common/includes/toplist/class.base.php
@@ -445,7 +445,7 @@ class TopList_Base
 
         if (count($this->systems_))
         {
-            $this->sql_ .= $op." kll.kll_system_id IN ( ".implode($this->systems_, ",").") ";
+            $this->sql_ .= $op." kll.kll_system_id IN ( ".implode(",", $this->systems_).") ";
             $op = " AND ";
         }
 

--- a/common/index.php
+++ b/common/index.php
@@ -88,9 +88,6 @@ header('Content-Type: text/html; charset=UTF-8');
 
 //edkloader::setRoot(getcwd());
 
-// smarty doesnt like it
-if(get_magic_quotes_runtime()) @set_magic_quotes_runtime(0);
-
 // load the config from the database
 $config = new Config();
 if(!config::get('cfg_kbhost'))

--- a/common/kill_detail.php
+++ b/common/kill_detail.php
@@ -328,17 +328,17 @@ class pKillDetail extends pageAssembly
                 $i_id = $item->getID();
                 $i_usedgroup = $item->get_used_launcher_group();
                                 
-                                // Nanite Repair Paste for ancillary armor repairers is a special snowflake
-                                // there are no type attributes indicating a used group
-                                // if item is nanite repair paste
-                                if($i_id == 28668) 
-                                {
-                                    // ancillary armor repairers
-                                    $i_usedgroup = 1199;
-                                }
+                // Nanite Repair Paste for ancillary armor repairers is a special snowflake
+                // there are no type attributes indicating a used group
+                // if item is nanite repair paste
+                if($i_id == 28668) 
+                {
+                    // ancillary armor repairers
+                    $i_usedgroup = 1199;
+                }
 
                 // BPCs
-                                $bpc = false;
+                $bpc = false;
                 if($dropped->getSingleton() == InventoryFlag::$SINGLETON_COPY) {
                     $i_name = $i_name." (Copy)";
                     $value = $formatted = 0;
@@ -357,11 +357,11 @@ class pKillDetail extends pageAssembly
                     'bpc' => $bpc
                 );
                                 
-                                // Generate Ship DNA array
-                                $this->items[$i_location][] = array (
-                                    'item' => $i_id,
-                                    'qty' => $i_qty
-                                );
+                // Generate Ship DNA array
+                $this->items[$i_location][] = array (
+                    'item' => $i_id,
+                    'qty' => $i_qty
+                );
 
                 //Fitting -KE, add dropped items to the list
                 if (($i_location != InventoryFlag::$CARGO )&& ($i_location != InventoryFlag::$DRONE_BAY)) {

--- a/common/xajax/xajax.php
+++ b/common/xajax/xajax.php
@@ -44,10 +44,11 @@ class edk_xajax
 
     public static function lateProcess()
     {
+        $class = get_class();	
         // let all mods know we're here so they can register their functions
-        event::call('xajax_initialised', get_class());
+        event::call('xajax_initialised', $class);
         // Also register this for old mods registered to the ajax mod.
-        event::call('mod_xajax_initialised', get_class());
+        event::call('mod_xajax_initialised', $class);
 
         // now process all xajax calls
         global $xajax;

--- a/common/xajax/xajax_core/xajaxArgumentManager.inc.php
+++ b/common/xajax/xajax_core/xajaxArgumentManager.inc.php
@@ -372,9 +372,6 @@ class xajaxArgumentManager
             $this->aArgs = $_GET['xjxargs'];
         }
         
-        if (1 == get_magic_quotes_gpc())
-            array_walk($this->aArgs, array(&$this, 'argumentStripSlashes'));
-        
         array_walk($this->aArgs, array(&$this, 'argumentDecodeXML'));
     }
     

--- a/update/030/update.php
+++ b/update/030/update.php
@@ -10,7 +10,7 @@ function update030()
     if (CURRENT_DB_UPDATE < "030") {
         $qry = DBFactory::getDBQuery(true);
 
-        $sql = 'ALTER IGNORE TABLE kb3_mails ADD COLUMN kll_crest_hash CHAR(40) DEFAULT NULL';
+        $sql = 'ALTER TABLE kb3_mails ADD COLUMN kll_crest_hash CHAR(40) DEFAULT NULL';
         $qry->execute($sql);
 
         config::set("DBUpdate", "030");


### PR DESCRIPTION
With a few tweaks I've been able to run the killboard on PHP 7.4 and MySQL 8 (without changing any of the strictness settings in MySQL). All my inventory images were borked so I included a fix for that, too.
Maybe someone still running a killboard will find these changes useful. The commit history describes the changes, but I realize this should probably be several PRs rather than one.

A few fixes of note:
- Removed a broken API call to ESI that used to fetch the remote alliance ID. That needs to be rewritten to fix it. All I did was remove the broken call. Alliance IDs still won't get updated properly.
- Updated to use CCP's newer image server, and updated the paths to the images so it actually works
- Fixed a few deprecation warnings.
- Fixed several GROUP BY clauses that were missing non-aggregate fields
- Did a bunch of work on the kill list (`class.killlist.php`) after fixing the GROUP BY clause led me down a rabbit hole to get the right columns listed. 

NOTE: When running the updates, the migrations crashed because some default timestamps were set to `0000-00-00 00:00:00`. I assume MySQL used to let you use that as a date, but these days it complains if you try to alter a table with a default like that. I manually set a proper default of a random date, but didn't actually write a migration to fix that for you. It only comes up if you try to run the updates from before 032 on MySQL 8. 